### PR TITLE
Fix inventory scrolling

### DIFF
--- a/blocklisttask.cpp
+++ b/blocklisttask.cpp
@@ -196,17 +196,25 @@ void BlockListTask::logic()
 
         key_held_down = true;
     }
-    else if (keyPressed(KEY_NSPIRE_2) || keyPressed(KEY_NSPIRE_DOWN) || keyPressed(KEY_NSPIRE_S))
+    else if(keyPressed(KEY_NSPIRE_2) || keyPressed(KEY_NSPIRE_DOWN) || keyPressed(KEY_NSPIRE_S))
     {
+        const int rows = ((user_selectable_count + fields_x - 1) / fields_x);
         // Increment current cell by row size and overflow
         current_selection += fields_x;
 
         if (current_selection >= user_selectable_count && !(current_selection - fields_x > user_selectable_count - fields_x))
             current_selection = user_selectable_count - 1;
-        
+
         if (current_selection >= user_selectable_count)
             current_selection %= fields_x;
-        
+
+        {
+            if (current_selection > rows * fields_x)
+                current_selection %= fields_x;
+            else
+                current_selection = user_selectable_count - 1;
+        }
+
         moveScreenOffset();
 
         key_held_down = true;
@@ -215,7 +223,7 @@ void BlockListTask::logic()
     {
         // (Here, there is a fast path, and a slow path for if the inventory size is not full)
         // Decrement current cell  by row size and underflow
-        
+
         if (current_selection >= fields_x)
             current_selection -= fields_x;
         else
@@ -224,6 +232,7 @@ void BlockListTask::logic()
             current_selection = ((user_selectable_count - 1) / fields_x) * fields_x + (current_selection % fields_x);
             if (current_selection >= user_selectable_count)
                 current_selection -= fields_x;
+                current_selection = user_selectable_count - 1;
         }
 
         moveScreenOffset();


### PR DESCRIPTION
This makes it so that if you press down on the second to last row, and the last row is not full, then the cursor will always land on it.
And when you press up, it will always land on the last row.