### PR TITLE
Add Special block destruction particles

### DIFF
--- a/blockrenderer.cpp
+++ b/blockrenderer.cpp
@@ -376,7 +376,7 @@ void UniversalBlockRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest,
     return map[getBLOCK(block)]->drawPreview(block, dest, x, y);
 }
 
-const TerrainAtlasEntry &DumbBlockRenderer::materialTexture(const BLOCK_WDATA block) {
+const TerrainAtlasEntry &BlockRenderer::materialTexture(const BLOCK_WDATA block) {
     auto block_nr = getBLOCK(block);
     if(block_nr <= BLOCK_NORMAL_LAST)
         return block_textures[block_nr][BLOCK_FRONT];

--- a/blockrenderer.cpp
+++ b/blockrenderer.cpp
@@ -376,8 +376,7 @@ void UniversalBlockRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest,
     return map[getBLOCK(block)]->drawPreview(block, dest, x, y);
 }
 
-const TerrainAtlasEntry &UniversalBlockRenderer::materialTexture(const BLOCK_WDATA block)
-{
+const TerrainAtlasEntry &BlockRenderer::materialTexture(const BLOCK_WDATA block) {
     auto block_nr = getBLOCK(block);
     if(block_nr <= BLOCK_NORMAL_LAST)
         return block_textures[block_nr][BLOCK_FRONT];
@@ -385,6 +384,11 @@ const TerrainAtlasEntry &UniversalBlockRenderer::materialTexture(const BLOCK_WDA
         return special_block_textures[block_nr - BLOCK_SPECIAL_START];
 
     return block_textures[BLOCK_STONE][BLOCK_FRONT];
+}
+
+const TerrainAtlasEntry &UniversalBlockRenderer::materialTexture(const BLOCK_WDATA block)
+{
+    return map[getBLOCK(block)]->materialTexture(block);
 }
 
 bool UniversalBlockRenderer::action(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, Chunk &c)

--- a/blockrenderer.cpp
+++ b/blockrenderer.cpp
@@ -376,7 +376,7 @@ void UniversalBlockRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest,
     return map[getBLOCK(block)]->drawPreview(block, dest, x, y);
 }
 
-const TerrainAtlasEntry &BlockRenderer::materialTexture(const BLOCK_WDATA block) {
+const TerrainAtlasEntry &BlockRenderer::destructionTexture(const BLOCK_WDATA block) {
     auto block_nr = getBLOCK(block);
     if(block_nr <= BLOCK_NORMAL_LAST)
         return block_textures[block_nr][BLOCK_FRONT];
@@ -386,9 +386,9 @@ const TerrainAtlasEntry &BlockRenderer::materialTexture(const BLOCK_WDATA block)
     return block_textures[BLOCK_STONE][BLOCK_FRONT];
 }
 
-const TerrainAtlasEntry &UniversalBlockRenderer::materialTexture(const BLOCK_WDATA block)
+const TerrainAtlasEntry &UniversalBlockRenderer::destructionTexture(const BLOCK_WDATA block)
 {
-    return map[getBLOCK(block)]->materialTexture(block);
+    return map[getBLOCK(block)]->destructionTexture(block);
 }
 
 bool UniversalBlockRenderer::action(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, Chunk &c)

--- a/blockrenderer.cpp
+++ b/blockrenderer.cpp
@@ -376,7 +376,7 @@ void UniversalBlockRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest,
     return map[getBLOCK(block)]->drawPreview(block, dest, x, y);
 }
 
-const TerrainAtlasEntry BlockRenderer::materialTexture(const BLOCK_WDATA block) {
+const TerrainAtlasEntry &BlockRenderer::materialTexture(const BLOCK_WDATA block) {
     auto block_nr = getBLOCK(block);
     if(block_nr <= BLOCK_NORMAL_LAST)
         return block_textures[block_nr][BLOCK_FRONT];
@@ -386,27 +386,7 @@ const TerrainAtlasEntry BlockRenderer::materialTexture(const BLOCK_WDATA block) 
     return block_textures[BLOCK_STONE][BLOCK_FRONT];
 }
 
-const TerrainAtlasEntry DumbBlockRenderer::materialTexture(const BLOCK_WDATA block) {
-    auto block_nr = getBLOCK(block);
-    if(block_nr <= BLOCK_NORMAL_LAST)
-        return block_textures[block_nr][BLOCK_FRONT];
-    else if(block_nr >= BLOCK_SPECIAL_START && block_nr <= BLOCK_SPECIAL_LAST)
-        return special_block_textures[block_nr - BLOCK_SPECIAL_START];
-
-    return block_textures[BLOCK_STONE][BLOCK_FRONT];
-}
-
-const TerrainAtlasEntry NormalBlockRenderer::materialTexture(const BLOCK_WDATA block) {
-    auto block_nr = getBLOCK(block);
-    if(block_nr <= BLOCK_NORMAL_LAST)
-        return block_textures[block_nr][BLOCK_FRONT];
-    else if(block_nr >= BLOCK_SPECIAL_START && block_nr <= BLOCK_SPECIAL_LAST)
-        return special_block_textures[block_nr - BLOCK_SPECIAL_START];
-
-    return block_textures[BLOCK_STONE][BLOCK_FRONT];
-}
-
-const TerrainAtlasEntry UniversalBlockRenderer::materialTexture(const BLOCK_WDATA block)
+const TerrainAtlasEntry &UniversalBlockRenderer::materialTexture(const BLOCK_WDATA block)
 {
     return map[getBLOCK(block)]->materialTexture(block);
 }

--- a/blockrenderer.cpp
+++ b/blockrenderer.cpp
@@ -376,7 +376,7 @@ void UniversalBlockRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest,
     return map[getBLOCK(block)]->drawPreview(block, dest, x, y);
 }
 
-const TerrainAtlasEntry &BlockRenderer::materialTexture(const BLOCK_WDATA block) {
+const TerrainAtlasEntry BlockRenderer::materialTexture(const BLOCK_WDATA block) {
     auto block_nr = getBLOCK(block);
     if(block_nr <= BLOCK_NORMAL_LAST)
         return block_textures[block_nr][BLOCK_FRONT];
@@ -386,7 +386,7 @@ const TerrainAtlasEntry &BlockRenderer::materialTexture(const BLOCK_WDATA block)
     return block_textures[BLOCK_STONE][BLOCK_FRONT];
 }
 
-const TerrainAtlasEntry &DumbBlockRenderer::materialTexture(const BLOCK_WDATA block) {
+const TerrainAtlasEntry DumbBlockRenderer::materialTexture(const BLOCK_WDATA block) {
     auto block_nr = getBLOCK(block);
     if(block_nr <= BLOCK_NORMAL_LAST)
         return block_textures[block_nr][BLOCK_FRONT];
@@ -396,7 +396,7 @@ const TerrainAtlasEntry &DumbBlockRenderer::materialTexture(const BLOCK_WDATA bl
     return block_textures[BLOCK_STONE][BLOCK_FRONT];
 }
 
-const TerrainAtlasEntry &NormalBlockRenderer::materialTexture(const BLOCK_WDATA block) {
+const TerrainAtlasEntry NormalBlockRenderer::materialTexture(const BLOCK_WDATA block) {
     auto block_nr = getBLOCK(block);
     if(block_nr <= BLOCK_NORMAL_LAST)
         return block_textures[block_nr][BLOCK_FRONT];
@@ -406,7 +406,7 @@ const TerrainAtlasEntry &NormalBlockRenderer::materialTexture(const BLOCK_WDATA 
     return block_textures[BLOCK_STONE][BLOCK_FRONT];
 }
 
-const TerrainAtlasEntry &UniversalBlockRenderer::materialTexture(const BLOCK_WDATA block)
+const TerrainAtlasEntry UniversalBlockRenderer::materialTexture(const BLOCK_WDATA block)
 {
     return map[getBLOCK(block)]->materialTexture(block);
 }

--- a/blockrenderer.cpp
+++ b/blockrenderer.cpp
@@ -386,6 +386,26 @@ const TerrainAtlasEntry &BlockRenderer::materialTexture(const BLOCK_WDATA block)
     return block_textures[BLOCK_STONE][BLOCK_FRONT];
 }
 
+const TerrainAtlasEntry &DumbBlockRenderer::materialTexture(const BLOCK_WDATA block) {
+    auto block_nr = getBLOCK(block);
+    if(block_nr <= BLOCK_NORMAL_LAST)
+        return block_textures[block_nr][BLOCK_FRONT];
+    else if(block_nr >= BLOCK_SPECIAL_START && block_nr <= BLOCK_SPECIAL_LAST)
+        return special_block_textures[block_nr - BLOCK_SPECIAL_START];
+
+    return block_textures[BLOCK_STONE][BLOCK_FRONT];
+}
+
+const TerrainAtlasEntry &NormalBlockRenderer::materialTexture(const BLOCK_WDATA block) {
+    auto block_nr = getBLOCK(block);
+    if(block_nr <= BLOCK_NORMAL_LAST)
+        return block_textures[block_nr][BLOCK_FRONT];
+    else if(block_nr >= BLOCK_SPECIAL_START && block_nr <= BLOCK_SPECIAL_LAST)
+        return special_block_textures[block_nr - BLOCK_SPECIAL_START];
+
+    return block_textures[BLOCK_STONE][BLOCK_FRONT];
+}
+
 const TerrainAtlasEntry &UniversalBlockRenderer::materialTexture(const BLOCK_WDATA block)
 {
     return map[getBLOCK(block)]->materialTexture(block);

--- a/blockrenderer.cpp
+++ b/blockrenderer.cpp
@@ -376,27 +376,7 @@ void UniversalBlockRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest,
     return map[getBLOCK(block)]->drawPreview(block, dest, x, y);
 }
 
-const TerrainAtlasEntry &BlockRenderer::materialTexture(const BLOCK_WDATA block) {
-    auto block_nr = getBLOCK(block);
-    if(block_nr <= BLOCK_NORMAL_LAST)
-        return block_textures[block_nr][BLOCK_FRONT];
-    else if(block_nr >= BLOCK_SPECIAL_START && block_nr <= BLOCK_SPECIAL_LAST)
-        return special_block_textures[block_nr - BLOCK_SPECIAL_START];
-
-    return block_textures[BLOCK_STONE][BLOCK_FRONT];
-}
-
 const TerrainAtlasEntry &DumbBlockRenderer::materialTexture(const BLOCK_WDATA block) {
-    auto block_nr = getBLOCK(block);
-    if(block_nr <= BLOCK_NORMAL_LAST)
-        return block_textures[block_nr][BLOCK_FRONT];
-    else if(block_nr >= BLOCK_SPECIAL_START && block_nr <= BLOCK_SPECIAL_LAST)
-        return special_block_textures[block_nr - BLOCK_SPECIAL_START];
-
-    return block_textures[BLOCK_STONE][BLOCK_FRONT];
-}
-
-const TerrainAtlasEntry &NormalBlockRenderer::materialTexture(const BLOCK_WDATA block) {
     auto block_nr = getBLOCK(block);
     if(block_nr <= BLOCK_NORMAL_LAST)
         return block_textures[block_nr][BLOCK_FRONT];

--- a/blockrenderer.h
+++ b/blockrenderer.h
@@ -23,7 +23,7 @@ public:
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int x, const int y) = 0;
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block);
+    virtual const TerrainAtlasEntry materialTexture(const BLOCK_WDATA block);
 
     static void renderNormalBlockSide(int local_x, int local_y, int local_z, const BLOCK_SIDE side, const TextureAtlasEntry &tex, Chunk &c, const COLOR color = 0);
     //Renders dx*dy*dz (depending on the side) block sides (max 2x2) at once
@@ -65,7 +65,7 @@ public:
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int x, const int y) override;
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
+    virtual const TerrainAtlasEntry materialTexture(const BLOCK_WDATA block) override;
 
     virtual bool action(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, Chunk &c) override;
     virtual void tick(const BLOCK_WDATA block, int local_x, int local_y, int local_z, Chunk &c) override;
@@ -94,7 +94,7 @@ class DumbBlockRenderer : public BlockRenderer
 
     virtual void drawPreview(const BLOCK_WDATA /*block*/, TEXTURE &/*dest*/, const int /*x*/, const int /*y*/) override { return; }
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
+    virtual const TerrainAtlasEntry materialTexture(const BLOCK_WDATA block) override;
 
     virtual bool action(const BLOCK_WDATA /*block*/, const int /*local_x*/, const int /*local_y*/, const int /*local_z*/, Chunk &/*c*/) override { return false; }
     virtual void tick(const BLOCK_WDATA /*block*/, int /*local_x*/, int /*local_y*/, int /*local_z*/, Chunk &/*c*/) override {}
@@ -118,7 +118,7 @@ public:
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int dest_x, const int dest_y) override;
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
+    virtual const TerrainAtlasEntry materialTexture(const BLOCK_WDATA block) override;
 
     virtual const char* getName(const BLOCK_WDATA block) override { return block_names[getBLOCK(block)]; }
 

--- a/blockrenderer.h
+++ b/blockrenderer.h
@@ -23,7 +23,7 @@ public:
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int x, const int y) = 0;
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block);
+    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) = 0;
 
     static void renderNormalBlockSide(int local_x, int local_y, int local_z, const BLOCK_SIDE side, const TextureAtlasEntry &tex, Chunk &c, const COLOR color = 0);
     //Renders dx*dy*dz (depending on the side) block sides (max 2x2) at once

--- a/blockrenderer.h
+++ b/blockrenderer.h
@@ -93,6 +93,8 @@ class DumbBlockRenderer : public BlockRenderer
     virtual AABB getAABB(const BLOCK_WDATA block, GLFix x, GLFix y, GLFix z) override;
 
     virtual void drawPreview(const BLOCK_WDATA /*block*/, TEXTURE &/*dest*/, const int /*x*/, const int /*y*/) override { return; }
+    // Used for particles spawned on destruction
+    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
 
     virtual bool action(const BLOCK_WDATA /*block*/, const int /*local_x*/, const int /*local_y*/, const int /*local_z*/, Chunk &/*c*/) override { return false; }
     virtual void tick(const BLOCK_WDATA /*block*/, int /*local_x*/, int /*local_y*/, int /*local_z*/, Chunk &/*c*/) override {}

--- a/blockrenderer.h
+++ b/blockrenderer.h
@@ -23,7 +23,7 @@ public:
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int x, const int y) = 0;
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry materialTexture(const BLOCK_WDATA block);
+    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block);
 
     static void renderNormalBlockSide(int local_x, int local_y, int local_z, const BLOCK_SIDE side, const TextureAtlasEntry &tex, Chunk &c, const COLOR color = 0);
     //Renders dx*dy*dz (depending on the side) block sides (max 2x2) at once
@@ -65,7 +65,7 @@ public:
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int x, const int y) override;
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry materialTexture(const BLOCK_WDATA block) override;
+    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
 
     virtual bool action(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, Chunk &c) override;
     virtual void tick(const BLOCK_WDATA block, int local_x, int local_y, int local_z, Chunk &c) override;
@@ -93,8 +93,6 @@ class DumbBlockRenderer : public BlockRenderer
     virtual AABB getAABB(const BLOCK_WDATA block, GLFix x, GLFix y, GLFix z) override;
 
     virtual void drawPreview(const BLOCK_WDATA /*block*/, TEXTURE &/*dest*/, const int /*x*/, const int /*y*/) override { return; }
-    // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry materialTexture(const BLOCK_WDATA block) override;
 
     virtual bool action(const BLOCK_WDATA /*block*/, const int /*local_x*/, const int /*local_y*/, const int /*local_z*/, Chunk &/*c*/) override { return false; }
     virtual void tick(const BLOCK_WDATA /*block*/, int /*local_x*/, int /*local_y*/, int /*local_z*/, Chunk &/*c*/) override {}
@@ -117,8 +115,6 @@ public:
     virtual bool isBlockShaped(const BLOCK_WDATA /*block*/) override { return true; }
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int dest_x, const int dest_y) override;
-    // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry materialTexture(const BLOCK_WDATA block) override;
 
     virtual const char* getName(const BLOCK_WDATA block) override { return block_names[getBLOCK(block)]; }
 

--- a/blockrenderer.h
+++ b/blockrenderer.h
@@ -115,6 +115,8 @@ public:
     virtual bool isBlockShaped(const BLOCK_WDATA /*block*/) override { return true; }
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int dest_x, const int dest_y) override;
+    // Used for particles spawned on destruction
+    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
 
     virtual const char* getName(const BLOCK_WDATA block) override { return block_names[getBLOCK(block)]; }
 

--- a/blockrenderer.h
+++ b/blockrenderer.h
@@ -22,6 +22,8 @@ public:
     virtual AABB getAABB(const BLOCK_WDATA block, GLFix x, GLFix y, GLFix z) = 0;
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int x, const int y) = 0;
+    // Used for particles spawned on destruction
+    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block);
 
     static void renderNormalBlockSide(int local_x, int local_y, int local_z, const BLOCK_SIDE side, const TextureAtlasEntry &tex, Chunk &c, const COLOR color = 0);
     //Renders dx*dy*dz (depending on the side) block sides (max 2x2) at once
@@ -63,7 +65,7 @@ public:
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int x, const int y) override;
     // Used for particles spawned on destruction
-    const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block);
+    const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
 
     virtual bool action(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, Chunk &c) override;
     virtual void tick(const BLOCK_WDATA block, int local_x, int local_y, int local_z, Chunk &c) override;

--- a/blockrenderer.h
+++ b/blockrenderer.h
@@ -23,7 +23,7 @@ public:
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int x, const int y) = 0;
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block);
+    virtual const TerrainAtlasEntry &destructionTexture(const BLOCK_WDATA block);
 
     static void renderNormalBlockSide(int local_x, int local_y, int local_z, const BLOCK_SIDE side, const TextureAtlasEntry &tex, Chunk &c, const COLOR color = 0);
     //Renders dx*dy*dz (depending on the side) block sides (max 2x2) at once
@@ -65,7 +65,7 @@ public:
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int x, const int y) override;
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
+    virtual const TerrainAtlasEntry &destructionTexture(const BLOCK_WDATA block) override;
 
     virtual bool action(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, Chunk &c) override;
     virtual void tick(const BLOCK_WDATA block, int local_x, int local_y, int local_z, Chunk &c) override;

--- a/blockrenderer.h
+++ b/blockrenderer.h
@@ -23,7 +23,7 @@ public:
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int x, const int y) = 0;
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) = 0;
+    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block);
 
     static void renderNormalBlockSide(int local_x, int local_y, int local_z, const BLOCK_SIDE side, const TextureAtlasEntry &tex, Chunk &c, const COLOR color = 0);
     //Renders dx*dy*dz (depending on the side) block sides (max 2x2) at once
@@ -65,7 +65,7 @@ public:
 
     virtual void drawPreview(const BLOCK_WDATA block, TEXTURE &dest, const int x, const int y) override;
     // Used for particles spawned on destruction
-    const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
+    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
 
     virtual bool action(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, Chunk &c) override;
     virtual void tick(const BLOCK_WDATA block, int local_x, int local_y, int local_z, Chunk &c) override;

--- a/lamprenderer.cpp
+++ b/lamprenderer.cpp
@@ -15,6 +15,10 @@ void LampRenderer::drawPreview(const BLOCK_WDATA /*block*/, TEXTURE &dest, int x
     BlockRenderer::drawTextureAtlasEntry(*terrain_resized, terrain_atlas[4][13].resized, dest, x, y);
 }
 
+const TerrainAtlasEntry &LampRenderer::materialTexture(const BLOCK_WDATA block) {
+    return static_cast<STATE>(getBLOCKDATA(block)) ? terrain_atlas[4][13] : terrain_atlas[3][13];
+}
+
 void LampRenderer::tick(const BLOCK_WDATA block, int local_x, int local_y, int local_z, Chunk &c)
 {
     STATE powered = c.isBlockPowered(local_x, local_y, local_z) ? ON : OFF;

--- a/lamprenderer.cpp
+++ b/lamprenderer.cpp
@@ -15,7 +15,7 @@ void LampRenderer::drawPreview(const BLOCK_WDATA /*block*/, TEXTURE &dest, int x
     BlockRenderer::drawTextureAtlasEntry(*terrain_resized, terrain_atlas[4][13].resized, dest, x, y);
 }
 
-const TerrainAtlasEntry &LampRenderer::materialTexture(const BLOCK_WDATA block) {
+const TerrainAtlasEntry &LampRenderer::destructionTexture(const BLOCK_WDATA block) {
     return static_cast<STATE>(getBLOCKDATA(block)) ? terrain_atlas[4][13] : terrain_atlas[3][13];
 }
 

--- a/lamprenderer.h
+++ b/lamprenderer.h
@@ -9,8 +9,8 @@ public:
     virtual void geometryNormalBlock(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, const BLOCK_SIDE side, Chunk &c) override;
     virtual void drawPreview(const BLOCK_WDATA, TEXTURE &dest, int x, int y) override;
      // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
-    
+    virtual const TerrainAtlasEntry &destructionTexture(const BLOCK_WDATA block) override;
+
     virtual void tick(const BLOCK_WDATA block, int local_x, int local_y, int local_z, Chunk &c) override;
     virtual const char* getName(const BLOCK_WDATA) override;
 

--- a/lamprenderer.h
+++ b/lamprenderer.h
@@ -8,6 +8,9 @@ class LampRenderer : public NormalBlockRenderer
 public:
     virtual void geometryNormalBlock(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, const BLOCK_SIDE side, Chunk &c) override;
     virtual void drawPreview(const BLOCK_WDATA, TEXTURE &dest, int x, int y) override;
+     // Used for particles spawned on destruction
+    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
+    
     virtual void tick(const BLOCK_WDATA block, int local_x, int local_y, int local_z, Chunk &c) override;
     virtual const char* getName(const BLOCK_WDATA) override;
 

--- a/woolrenderer.cpp
+++ b/woolrenderer.cpp
@@ -4,7 +4,7 @@
 
 void WoolRenderer::geometryNormalBlock(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, const BLOCK_SIDE side, Chunk &c)
 {
-    TerrainAtlasEntry &tae = terrain_atlas[0][4];
+    TerrainAtlasEntry tae = terrain_atlas[0][4];
 
     switch (static_cast<COLOUR>(getBLOCKDATA(block))) {
         case WHITE_WOOL:
@@ -62,7 +62,7 @@ void WoolRenderer::geometryNormalBlock(const BLOCK_WDATA block, const int local_
 
 void WoolRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest, int x, int y)
 {
-    TerrainAtlasEntry &tae = terrain_atlas[0][4];
+    TerrainAtlasEntry tae = terrain_atlas[0][4];
 
     switch (static_cast<COLOUR>(getBLOCKDATA(block))) {
         case WHITE_WOOL:

--- a/woolrenderer.cpp
+++ b/woolrenderer.cpp
@@ -121,7 +121,7 @@ void WoolRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest, int x, in
     BlockRenderer::drawTextureAtlasEntry(*terrain_resized, tae.resized, dest, x, y);
 }
 
-const TerrainAtlasEntry &WoolRenderer::materialTexture(const BLOCK_WDATA block) {
+const TerrainAtlasEntry &WoolRenderer::destructionTexture(const BLOCK_WDATA block) {
     switch (static_cast<COLOUR>(getBLOCKDATA(block))) {
         case WHITE_WOOL:
             return terrain_atlas[0][4];

--- a/woolrenderer.cpp
+++ b/woolrenderer.cpp
@@ -4,7 +4,7 @@
 
 void WoolRenderer::geometryNormalBlock(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, const BLOCK_SIDE side, Chunk &c)
 {
-    TerrainAtlasEntry tae = terrain_atlas[0][4];
+    TerrainAtlasEntry &tae = terrain_atlas[0][4];
 
     switch (static_cast<COLOUR>(getBLOCKDATA(block))) {
         case WHITE_WOOL:
@@ -62,7 +62,7 @@ void WoolRenderer::geometryNormalBlock(const BLOCK_WDATA block, const int local_
 
 void WoolRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest, int x, int y)
 {
-    TerrainAtlasEntry tae = terrain_atlas[0][4];
+    TerrainAtlasEntry &tae = terrain_atlas[0][4];
 
     switch (static_cast<COLOUR>(getBLOCKDATA(block))) {
         case WHITE_WOOL:
@@ -113,15 +113,51 @@ void WoolRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest, int x, in
         case BLACK_WOOL:
             tae = terrain_atlas[1][7];
             break;
+        default:
+            tae = terrain_atlas[0][4];
+            break;
     }
 
     BlockRenderer::drawTextureAtlasEntry(*terrain_resized, tae.resized, dest, x, y);
 }
 
 const TerrainAtlasEntry &WoolRenderer::materialTexture(const BLOCK_WDATA block) {
-    TerrainAtlasEntry &tae = terrain_atlas[1][8];
-
-    return tae;
+    switch (static_cast<COLOUR>(getBLOCKDATA(block))) {
+        case WHITE_WOOL:
+            return terrain_atlas[0][4];
+        case ORANGE_WOOL:
+            return terrain_atlas[2][13];
+        case MAGENTA_WOOL:
+            return terrain_atlas[2][12];
+        case LIGHT_BLUE_WOOL:
+            return terrain_atlas[2][11];
+        case YELLOW_WOOL:
+            return terrain_atlas[2][10];
+        case LIME_WOOL:
+            return terrain_atlas[2][9];
+        case PINK_WOOL:
+            return terrain_atlas[2][8];
+        case GRAY_WOOL:
+            return terrain_atlas[2][7];
+        case LIGHT_GRAY_WOOL:
+            return terrain_atlas[1][14];
+        case CYAN_WOOL:
+            return terrain_atlas[1][13];
+        case PURPLE_WOOL:
+            return terrain_atlas[1][12];
+        case BLUE_WOOL:
+            return terrain_atlas[1][11];
+        case BROWN_WOOL:
+            return terrain_atlas[1][10];
+        case GREEN_WOOL:
+            return terrain_atlas[1][9];
+        case RED_WOOL:
+            return terrain_atlas[1][8];
+        case BLACK_WOOL:
+            return terrain_atlas[1][7];
+        default:
+            return terrain_atlas[0][4];
+    }
 }
 
 const char *WoolRenderer::getName(const BLOCK_WDATA block)
@@ -129,53 +165,37 @@ const char *WoolRenderer::getName(const BLOCK_WDATA block)
     switch (static_cast<COLOUR>(getBLOCKDATA(block))) {
         case WHITE_WOOL:
             return "White Wool";
-            break;
         case ORANGE_WOOL:
             return "Orange Wool";
-            break;
         case MAGENTA_WOOL:
             return "Magenta Wool";
-            break;
         case LIGHT_BLUE_WOOL:
             return "Light Blue Wool";
-            break;
         case YELLOW_WOOL:
             return "Yellow Wool";
-            break;
         case LIME_WOOL:
             return "Lime Wool";
-            break;
         case PINK_WOOL:
             return "Pink Wool";
-            break;
         case GRAY_WOOL:
             return "Gray Wool";
-            break;
         case LIGHT_GRAY_WOOL:
             return "Light Gray Wool";
-            break;
         case CYAN_WOOL:
             return "Cyan Wool";
-            break;
         case PURPLE_WOOL:
             return "Purple Wool";
-            break;
         case BLUE_WOOL:
             return "Blue Wool";
-            break;
         case BROWN_WOOL:
             return "Brown Wool";
-            break;
         case GREEN_WOOL:
             return "Green Wool";
-            break;
         case RED_WOOL:
             return "Red Wool";
-            break;
         case BLACK_WOOL:
             return "Black Wool";
-            break;
+        default:
+            return "Wool";
     }
-
-    return "Wool";
 }

--- a/woolrenderer.cpp
+++ b/woolrenderer.cpp
@@ -118,6 +118,12 @@ void WoolRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest, int x, in
     BlockRenderer::drawTextureAtlasEntry(*terrain_resized, tae.resized, dest, x, y);
 }
 
+const TerrainAtlasEntry &BlockRenderer::materialTexture(const BLOCK_WDATA block) {
+    TerrainAtlasEntry tae = terrain_atlas[1][8];
+
+    return tae;
+}
+
 const char *WoolRenderer::getName(const BLOCK_WDATA block)
 {
     switch (static_cast<COLOUR>(getBLOCKDATA(block))) {

--- a/woolrenderer.cpp
+++ b/woolrenderer.cpp
@@ -118,7 +118,7 @@ void WoolRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest, int x, in
     BlockRenderer::drawTextureAtlasEntry(*terrain_resized, tae.resized, dest, x, y);
 }
 
-const TerrainAtlasEntry &BlockRenderer::materialTexture(const BLOCK_WDATA block) {
+const TerrainAtlasEntry BlockRenderer::materialTexture(const BLOCK_WDATA block) {
     TerrainAtlasEntry &tae = terrain_atlas[1][8];
 
     return tae;

--- a/woolrenderer.cpp
+++ b/woolrenderer.cpp
@@ -119,7 +119,7 @@ void WoolRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest, int x, in
 }
 
 const TerrainAtlasEntry &BlockRenderer::materialTexture(const BLOCK_WDATA block) {
-    TerrainAtlasEntry tae = terrain_atlas[1][8];
+    TerrainAtlasEntry &tae = terrain_atlas[1][8];
 
     return tae;
 }

--- a/woolrenderer.cpp
+++ b/woolrenderer.cpp
@@ -118,7 +118,7 @@ void WoolRenderer::drawPreview(const BLOCK_WDATA block, TEXTURE &dest, int x, in
     BlockRenderer::drawTextureAtlasEntry(*terrain_resized, tae.resized, dest, x, y);
 }
 
-const TerrainAtlasEntry BlockRenderer::materialTexture(const BLOCK_WDATA block) {
+const TerrainAtlasEntry &WoolRenderer::materialTexture(const BLOCK_WDATA block) {
     TerrainAtlasEntry &tae = terrain_atlas[1][8];
 
     return tae;

--- a/woolrenderer.h
+++ b/woolrenderer.h
@@ -9,7 +9,7 @@ public:
     virtual void geometryNormalBlock(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, const BLOCK_SIDE side, Chunk &c) override;
     virtual void drawPreview(const BLOCK_WDATA, TEXTURE &dest, int x, int y) override;
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry materialTexture(const BLOCK_WDATA block) override;
+    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
 
     virtual const char* getName(const BLOCK_WDATA) override;
 

--- a/woolrenderer.h
+++ b/woolrenderer.h
@@ -9,7 +9,7 @@ public:
     virtual void geometryNormalBlock(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, const BLOCK_SIDE side, Chunk &c) override;
     virtual void drawPreview(const BLOCK_WDATA, TEXTURE &dest, int x, int y) override;
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
+    virtual const TerrainAtlasEntry &destructionTexture(const BLOCK_WDATA block) override;
 
     virtual const char* getName(const BLOCK_WDATA) override;
 

--- a/woolrenderer.h
+++ b/woolrenderer.h
@@ -9,7 +9,7 @@ public:
     virtual void geometryNormalBlock(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, const BLOCK_SIDE side, Chunk &c) override;
     virtual void drawPreview(const BLOCK_WDATA, TEXTURE &dest, int x, int y) override;
     // Used for particles spawned on destruction
-    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
+    virtual const TerrainAtlasEntry materialTexture(const BLOCK_WDATA block) override;
 
     virtual const char* getName(const BLOCK_WDATA) override;
 

--- a/woolrenderer.h
+++ b/woolrenderer.h
@@ -8,6 +8,9 @@ class WoolRenderer : public NormalBlockRenderer
 public:
     virtual void geometryNormalBlock(const BLOCK_WDATA block, const int local_x, const int local_y, const int local_z, const BLOCK_SIDE side, Chunk &c) override;
     virtual void drawPreview(const BLOCK_WDATA, TEXTURE &dest, int x, int y) override;
+    // Used for particles spawned on destruction
+    virtual const TerrainAtlasEntry &materialTexture(const BLOCK_WDATA block) override;
+
     virtual const char* getName(const BLOCK_WDATA) override;
 
 protected:

--- a/world.cpp
+++ b/world.cpp
@@ -295,7 +295,7 @@ void World::spawnDestructionParticles(int x, int y, int z)
     auto block = c->getLocalBlock(cx, cy, cz);
     Particle p;
     p.size = 14;
-    p.tae = global_block_renderer.materialTexture(block).current;
+    p.tae = global_block_renderer.destructionTexture(block).current;
 
     // Use the center quarter of the texture
     const int tex_width = p.tae.right - p.tae.left,


### PR DESCRIPTION
Give special blocks the ability to override `destructionTexture` (replacement for `materialTexture`) which is the texture for the particles which will spawn when a block is broken.

This means that blocks such as wool will display particles properly and also fixes some problems with the current implementation.